### PR TITLE
Update paginator padding to vertically-center text

### DIFF
--- a/site_assets/css/style.css
+++ b/site_assets/css/style.css
@@ -3106,7 +3106,7 @@ ul.bullets {
 
 .paginator a {
 	display: inline-block;
-	padding: 0 12px;
+	padding: 2px 12px 0 12px;
 	font-size: 12px;
 	line-height: 24px;
 	text-transform: uppercase;


### PR DESCRIPTION
This might not be the best way to fix this, but since `vertical-align: middle;` didn’t work, I put in exact pixel values in the padding.

![paginator](https://f.cloud.github.com/assets/293844/1916473/af8301ae-7d79-11e3-8085-dc9104581a03.gif)
