### PR TITLE
Use anchor links for subhead instead of pseudo elements

### DIFF
--- a/site_assets/css/style.css
+++ b/site_assets/css/style.css
@@ -1985,32 +1985,6 @@ html[data-useragent*='Chrome'][data-platform*='Mac'] .article-layout .main-conte
 	margin-left: 0;
 }
 
-.hentry .main-content *[id*="section"]:hover,
-.hentry .main-content *[id*="section"]:target,
-.hentry .main-content *[id*="figure"]:hover,
-.hentry .main-content *[id*="figure"]:target,
-.hentry .main-content *[id*="snippet"]:hover,
-.hentry .main-content *[id*="snippet"]:target {
-	position: relative;
-	cursor: default;
-}
-
-.hentry .main-content *[id*="section"]:hover:after,
-.hentry .main-content *[id*="section"]:target:after,
-.hentry .main-content *[id*="figure"]:hover:after,
-.hentry .main-content *[id*="figure"]:target:after,
-.hentry .main-content *[id*="snippet"]:hover:after,
-.hentry .main-content *[id*="snippet"]:target:after {
-	content: "#" attr(id);
-	display: inline-block;
-	vertical-align: middle;
-	padding-left: 12px;
-	color: #ccc;
-	font-size: 12px;
-	line-height: 12px;
-	text-transform: none;
-}
-
 .hentry .main-content *[id*="figure"]:hover:after,
 .hentry .main-content *[id*="figure"]:target:after,
 .hentry .main-content *[id*="snippet"]:hover:after,
@@ -2021,6 +1995,24 @@ html[data-useragent*='Chrome'][data-platform*='Mac'] .article-layout .main-conte
 	top: 6px;
 	margin-right: 12px;
 	font-family: "Franklin ITC Pro Bold", sans-serif;
+}
+
+.subhead-anchor {
+  color: #ccc;
+  display: none;
+  font-size: 12px;
+  line-height: 12px;
+  padding-left: 12px;
+  text-transform: none;
+	vertical-align: middle;
+}
+
+.hentry .main-content h2:hover .subhead-anchor {
+  display: inline-block;
+}
+
+.subhead-anchor:hover {
+  text-decoration: underline;
 }
 
 .entry-footnotes {

--- a/site_assets/js/script.js
+++ b/site_assets/js/script.js
@@ -53,6 +53,7 @@ $(document).ready(function(){
 		
 		count1++;
 		$(this).attr("id", "section" + count1);
+    $(this).append("<a class='subhead-anchor' href='#section" + count1 + "'>#section" + count1 + "</a>'");
 
 	});
 	


### PR DESCRIPTION
When I hover over a subhead (h2), the section anchor appears, which is pretty awesome.

![screenshot 2014-01-15 12 45 16](https://f.cloud.github.com/assets/651753/1922905/d2ab4590-7e0c-11e3-8f16-1c74f68ec90f.png)

However, that element should be clickable, so I can easily link other readers to that section.

I have **not** tested this, merely meant as a suggestion and starting place. Good luck! :fireworks: Love A List Apart!
