### PR TITLE
add role banner on the consistent header

### DIFF
--- a/snippets/default_site/primary-logo.snip
+++ b/snippets/default_site/primary-logo.snip
@@ -1,4 +1,4 @@
-	<header class="logo-holder">
+	<header class="logo-holder" role="banner">
 	
 		<h1 name="top" class="killer-logo"><a href="/"><img src="//d.alistapart.com/site_assets/img/ala-logo-big.png" alt="A List Apart"></a></h1>
 		


### PR DESCRIPTION
As per discussion in https://github.com/alistapart/AListApart/pull/26 added role="banner" to the site-wide header info.

role banner more info: http://www.w3.org/TR/wai-aria/roles#banner
