### PR TITLE
Fixed relative url in comment embed

### DIFF
--- a/snippets/default_site/single-comment.snip
+++ b/snippets/default_site/single-comment.snip
@@ -65,7 +65,7 @@ EOD;
 										}
 										echo implode($new_lines);?>
 										
-<script async data-comment="{comment_id}" charset="utf-8" src="/d/_repo/site_assets/js/comment-embed.min.js"></script></textarea>
+<script async data-comment="{comment_id}" charset="utf-8" src="//alistapart.com/d/_repo/site_assets/js/comment-embed.min.js"></script></textarea>
 									
 									<div class="button-holder">
 										<input type="submit" name="cancel" value="Close" class="cancel-embed">


### PR DESCRIPTION
The embed code was referencing the comment-embed.js script by relative url. Mistake by replace-all?