### PR TITLE
Fix login URL when JavaScript is disabled.

### DIFF
--- a/snippets/default_site/comment-sign-in.snip
+++ b/snippets/default_site/comment-sign-in.snip
@@ -30,7 +30,7 @@
 									<ul class="login-buttons">
 										<li class="twitter"><a href="http://alistapart.com/?ACT=59&provider=twitter&RET={exp:current_url:full_url}/login-return">Twitter</a></li><!--
 										--><li class="facebook"><a href="http://alistapart.com/?ACT=59&provider=facebook&RET={exp:current_url:full_url}/login-return">Facebook</a></li><!--
-										--><li class="ala"><a id="show-native-login" href="/login">A List Apart</a></li>
+										--><li class="ala"><a id="show-native-login" href="/tools/log-in">A List Apart</a></li>
 									</ul>
 								</div>
 								


### PR DESCRIPTION
I noticed when I went to look at comments on my article after I'd been testing with JavaScript disabled that the sign in with A List Apart button didn't work.

I've changed it to use the same URL as the login link in the footer.

I can't test it locally, but I *think* this should solve the problem.