### PR TITLE
Removing meta imagetoolbar

### DIFF
--- a/templates/snippets/default_site/global-page-top.snip
+++ b/templates/snippets/default_site/global-page-top.snip
@@ -30,8 +30,6 @@
 
 	<link href="https://plus.google.com/+alistapart/" rel="publisher" />
 
-	<meta http-equiv="imagetoolbar" content="false" />
-
 	{exp:minimee:css}
 	<link rel="stylesheet" href="/{assets_path}/css/reset.css" />
 	<link rel="stylesheet" href="/{assets_path}/css/style.css" />


### PR DESCRIPTION
This is causing HTML validator to choke. It was for IE6, so you can
probably remove it. More validation fixes to come.