### PR TITLE
Remove leading zeros from displayed dates.

### DIFF
--- a/templates/default_site/articles.group/index.html
+++ b/templates/default_site/articles.group/index.html
@@ -54,7 +54,7 @@
 							{if channel_short_name == 'legacy_articles'}
 							<span itemprop="author" itemscope itemtype="http://schema.org/Person">by {legacy_article_authors backspace="2"}<a itemprop="url" class="author" rel="author" href="/author/{legacy_article_authors:url_title}"><span itemprop="name">{legacy_article_authors:title}</span></a>, {/legacy_article_authors}</span>
 							{/if} ·
-							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 							{if comment_total > 0}
 							 · <a class="comment-count" href="/article/{url_title}#comments">{comment_total} Comment{if comment_total > 1}s{/if}</a>
 							 {/if}

--- a/templates/default_site/blog.group/index.html
+++ b/templates/default_site/blog.group/index.html
@@ -41,7 +41,7 @@
 
 					<p class="entry-details">
 
-						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 
 						{if comment_total > 0}
 						 · <a class="comment-count" href="/blog/post/{url_title}#comments">{comment_total} Comment{if comment_total > 1}s{/if}</a>

--- a/templates/default_site/blog.group/post-dev.html
+++ b/templates/default_site/blog.group/post-dev.html
@@ -59,12 +59,12 @@
 							{if channel_short_name == 'legacy_articles'}
 							<span itemprop="author" itemscope itemtype="http://schema.org/Person">by {legacy_article_authors backspace="2"}<a itemprop="url" class="author" rel="author" href="/author/{legacy_article_authors:url_title}"><span itemprop="name">{legacy_article_authors:title}</span></a>, {/legacy_article_authors}</span>
 							{/if} ·
-							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 							{if comment_total > 0}
 							 · <a class="comment-count" href="/article/{url_title}#comments">{comment_total} Comment{if comment_total > 1}s{/if}</a>
 							 {/if} ·
 
-					<time class="article-pubdate" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>{!-- ·
+					<time class="article-pubdate" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>{!-- ·
 
 					Published in {categories backspace="2"}<a href="/topic/{category_url_title}">{category_name}</a>, {/categories--}
 

--- a/templates/default_site/blog.group/post.html
+++ b/templates/default_site/blog.group/post.html
@@ -56,7 +56,7 @@
 
 					{if blog_hide_author != "y"}<span itemprop="author" itemscope itemtype="http://schema.org/Person">by {blog_authors backspace="2"}<a itemprop="url" class="author" rel="author" href="/author/{blog_authors:url_title}"><span itemprop="name">{blog_authors:title}</span></a>, {/blog_authors} · </span>{/if}
 
-					<time class="article-pubdate" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}" itemprop="datePublished">{entry_date format="%F %d, %Y"}</time>
+					<time class="article-pubdate" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}" itemprop="datePublished">{entry_date format="%F %j, %Y"}</time>
 
 				</p>
 

--- a/templates/default_site/blog.group/post_skeleton.html
+++ b/templates/default_site/blog.group/post_skeleton.html
@@ -42,7 +42,7 @@
 		
 			<p class="article-byline">by {embed="embeds/article-authors" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"}</p>
 			
-			<time class="article-pubdate" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+			<time class="article-pubdate" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 			
 			<p class="article-categories">Published in {categories backspace="2"}<a href="/topic/{category_url_title}">{category_name}</a>, {/categories}</p>
 			

--- a/templates/default_site/column.group/index.html
+++ b/templates/default_site/column.group/index.html
@@ -52,7 +52,7 @@
 
 				<p class="entry-details">
 
-					<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}" itemprop="datePublished">{entry_date format="%F %d, %Y"}</time>
+					<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}" itemprop="datePublished">{entry_date format="%F %j, %Y"}</time>
 
 					<span class="entry-meta optional-break">
 

--- a/templates/default_site/column.group/index_sekeleton.html
+++ b/templates/default_site/column.group/index_sekeleton.html
@@ -42,7 +42,7 @@
 		
 			<p class="article-byline">by {embed="embeds/article-authors" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"}</p>
 			
-			<time class="article-pubdate" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+			<time class="article-pubdate" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 			
 			<p class="article-categories">Published in {categories backspace="2"}<a href="/topic/{category_url_title}">{category_name}</a>, {/categories}</p>
 			

--- a/templates/default_site/columns.group/index.html
+++ b/templates/default_site/columns.group/index.html
@@ -62,7 +62,7 @@
 						<h1><a href="/column/{url_title}">{title}</a></h1>
 
 						<p class="meta">
-							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time> ·
+							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time> ·
 
 							Published in {modern-categories}
 
@@ -106,7 +106,7 @@
 							<h1><a href="/column/{url_title}">{title}</a></h1>
 
 							<p class="meta">
-								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 								{if comment_total > 0}
 								· <a class="comment-count" href="/column/{url_title}#comments">{comment_total} Comment{if comment_total > 1}s{/if}</a>
 								{/if}

--- a/templates/default_site/comments.group/index.html
+++ b/templates/default_site/comments.group/index.html
@@ -38,7 +38,7 @@
 
 					<span itemprop="author" itemscope itemtype="http://schema.org/Person">by {embed="embeds/article-authors-primary" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"}</span>
 
-					{exp:playa:parents status="open|In Progress"}<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}" itemprop="datePublished">{entry_date format="%F %d, %Y"}</time>{/exp:playa:parents}
+					{exp:playa:parents status="open|In Progress"}<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}" itemprop="datePublished">{entry_date format="%F %j, %Y"}</time>{/exp:playa:parents}
 
 					<span class="entry-meta optional-break">
 

--- a/templates/default_site/embeds.group/author-articles.html
+++ b/templates/default_site/embeds.group/author-articles.html
@@ -10,17 +10,17 @@
 						{if channel_short_name == "articles" || channel_short_name == "legacy_articles"}
 						<p class="meta">
 						<!-- {exp:playa:parents channel="issues"}<a href="/issue/{issue_number}">Issue&nbsp;{issue_number}</a>{/exp:playa:parents}&nbsp;·&nbsp; -->
-						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time></p>
+						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time></p>
 						<p>{exp:ala_typography:inline}{article_deck}{legacy_article_deck}{/exp:ala_typography:inline}</p>
 						{if:elseif channel_short_name == "blog" || channel_short_name == "events"}
 						<p class="meta">
-						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 						</p>
 
 						<p>{exp:ala_typography:inline}{blog_intro}{event_deck}{/exp:ala_typography:inline}</p>
 						{if:else}
 						<p class="meta">
-						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 						</p>
 
 						<p>{exp:ala_typography:inline}{column_intro}{/exp:ala_typography:inline}</p>

--- a/templates/default_site/embeds.group/author-events.html
+++ b/templates/default_site/embeds.group/author-events.html
@@ -5,7 +5,7 @@
 						<li>	
 							<h3 class="entry-title"><a href="{path='event/{url_title}'}">{title}</a></h3>
 							<p class="meta">
-								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 							</p> 
 							{event_deck}
 						</li>

--- a/templates/default_site/embeds.group/blog-posts-new.html
+++ b/templates/default_site/embeds.group/blog-posts-new.html
@@ -13,7 +13,7 @@
 						<h3 class="entry-title"><a href="/blog/post/{url_title}">{title}</a></h3>
 						<p class="meta">
 							<span itemprop="author" itemscope itemtype="http://schema.org/Person">by {blog_authors backspace="2"}<a itemprop="url" class="author" rel="author" href="/author/{blog_authors:url_title}"><span itemprop="name">{blog_authors:title}</span></a>, {/blog_authors}</span> ·
-							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 							{if comment_total > 0}
 							 · <a class="comment-count" href="/blog/post/{url_title}#comments">{comment_total} Comment{if comment_total > 1}s{/if}</a>
 							 {/if}

--- a/templates/default_site/embeds.group/blog-posts.html
+++ b/templates/default_site/embeds.group/blog-posts.html
@@ -12,7 +12,7 @@
 					<footer class="byline">
 
 						by {embed="embeds/article-authors" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"}
-						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 						{if comment_total > 0}
 							 · <a class="comment-count" href="/blog/post/{url_title}#comments">{comment_total} Comment{if comment_total > 1}s{/if}</a>
 						{/if}

--- a/templates/default_site/embeds.group/column-list.html
+++ b/templates/default_site/embeds.group/column-list.html
@@ -10,7 +10,7 @@
 						<h3 class="entry-title"><a href="/column/{url_title}">{title}</a></h3>
 						<p class="meta">
 							<span itemprop="author" itemscope itemtype="http://schema.org/Person">by {column_authors backspace="2"}<a itemprop="url" class="author" rel="author" href="/author/{column_authors:url_title}"><span itemprop="name">{column_authors:title}</span></a>, {/column_authors}</span> ·
-							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 							{if comment_total > 0}
 							 · <a class="comment-count" href="/column/{url_title}#comments">{comment_total} Comment{if comment_total > 1}s{/if}</a>
 							 {/if}

--- a/templates/default_site/embeds.group/columnist-more.html
+++ b/templates/default_site/embeds.group/columnist-more.html
@@ -2,7 +2,7 @@
 				{exp:user:authors entry_id="{embed:entry_id}"}
 				{exp:user:entries channel="columns" user_author_id="{member_id}" limit="1" offset="1" entry_id="not {embed:entry_id}"}
 				{if {embed:entry_id} != {entry_id}}
-						<time datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+						<time datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 						
 						<h2><a href="/column/{url_title}">{title}</a></h2>
 				{/if}

--- a/templates/default_site/embeds.group/illustrator-articles-kevin.html
+++ b/templates/default_site/embeds.group/illustrator-articles-kevin.html
@@ -25,7 +25,7 @@
 							{/if}
 							</a>
 							{/article_illustration}
-							<figcaption><a href="/article/{url_title}">{title}</a>&nbsp;·&nbsp;{entry_date format="%F %d, %Y"}</figcaption>
+							<figcaption><a href="/article/{url_title}">{title}</a>&nbsp;·&nbsp;{entry_date format="%F %j, %Y"}</figcaption>
 						</figure>
 
 

--- a/templates/default_site/embeds.group/issue-list-simple.html
+++ b/templates/default_site/embeds.group/issue-list-simple.html
@@ -2,7 +2,7 @@
 
 				{exp:channel:entries channel="issues" limit="999" status="open" dynamic="off" show_future_entries="no"}
 				
-				<li><a href="/issue/{issue_number}">Issue № {issue_number}</a>, {entry_date format="%F %d, %Y"}</li>
+				<li><a href="/issue/{issue_number}">Issue № {issue_number}</a>, {entry_date format="%F %j, %Y"}</li>
 				
 				{/exp:channel:entries}
 			

--- a/templates/default_site/embeds.group/issue-list.html
+++ b/templates/default_site/embeds.group/issue-list.html
@@ -14,7 +14,7 @@
 						<h3 class="entry-title"><a href="/article/{url_title}">{title}</a></h3>
 						<p class="meta">
 							by {embed="embeds/article-authors" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"} ·
-							<time class="pubdate updated" datetime="{exp:playa:parents channel='issues'}{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}{/exp:playa:parents">{exp:playa:parents channel='issues'}{entry_date format="%F %d, %Y"}{/exp:playa:parents}</time>
+							<time class="pubdate updated" datetime="{exp:playa:parents channel='issues'}{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}{/exp:playa:parents">{exp:playa:parents channel='issues'}{entry_date format="%F %j, %Y"}{/exp:playa:parents}</time>
 							{if comment_total > 0}
 							 · <a class="comment-count" href="/article/{url_title}#comments">{comment_total} Comment{if comment_total > 1}s{/if}</a>
 							 {/if}

--- a/templates/default_site/embeds.group/topic-list.html
+++ b/templates/default_site/embeds.group/topic-list.html
@@ -20,7 +20,7 @@
 							{if channel_short_name == 'legacy_articles'}
 							<span itemprop="author" itemscope itemtype="http://schema.org/Person">by {legacy_article_authors backspace="2"}<a itemprop="url" class="author" rel="author" href="/author/{legacy_article_authors:url_title}"><span itemprop="name">{legacy_article_authors:title}</span></a>, {/legacy_article_authors}</span>
 							{/if} ·
-							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 						</p>
 						{if channel_short_name == "articles" || channel_short_name == "legacy_articles"}
 						<p>{exp:ala_typography:inline}{exp:strip_html}{article_deck}{legacy_article_deck}{/exp:strip_html}{/exp:ala_typography:inline}</p>

--- a/templates/default_site/event.group/index.html
+++ b/templates/default_site/event.group/index.html
@@ -203,7 +203,7 @@
 						<h1><a href="/event/{url_title}">{title}</a></h1>
 
 						<p class="meta">
-							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 						</p>
 
 					</header>

--- a/templates/default_site/events.group/index.html
+++ b/templates/default_site/events.group/index.html
@@ -67,7 +67,7 @@
 						<h1><a href="/event/{url_title}">{title}</a></h1>
 
 						<p class="meta">
-							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 						</p>
 
 					</header>

--- a/templates/default_site/issue-preview.group/index.html
+++ b/templates/default_site/issue-preview.group/index.html
@@ -109,7 +109,7 @@
 						<p>{column_intro}</p>
 
 						<footer class="byline">
-							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 						</footer>
 
 					</article>
@@ -151,7 +151,7 @@
 
 						<footer>
 							<a class="author" href="/author/{embed:entry_username}">{author}</a>
-							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %d, %Y"}</a></time>
+							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %j, %Y"}</a></time>
 						</footer>
 
 					</article>

--- a/templates/default_site/issue.group/index.html
+++ b/templates/default_site/issue.group/index.html
@@ -125,7 +125,7 @@
 							{if "{categories}{category_url_title}{/categories}"!=""}
 							{embed="embeds/primary-category-logic-homepage" id="{entry_id}"}
 							·{/if}
-							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="{if channel_short_name == "columns"}column/{if:elseif channel_short_name == "blog"}blog/post/{if:elseif channel_short_name == "events"}event/{if:else}article/{/if}{url_title}">{entry_date format="%F %d, %Y"}</a></time>
+							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="{if channel_short_name == "columns"}column/{if:elseif channel_short_name == "blog"}blog/post/{if:elseif channel_short_name == "events"}event/{if:else}article/{/if}{url_title}">{entry_date format="%F %j, %Y"}</a></time>
 						</footer>
 
 					</article>
@@ -168,7 +168,7 @@
 						{if "{categories}{category_url_title}{/categories}"!=""}
 						{embed="embeds/primary-category-logic-homepage" id="{entry_id}"}
 						·{/if}
-						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="{if channel_short_name == "columns"}column/{if:elseif channel_short_name == "blog"}blog/post/{if:elseif channel_short_name == "events"}event/{if:else}article/{/if}{url_title}">{entry_date format="%F %d, %Y"}</a></time>
+						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="{if channel_short_name == "columns"}column/{if:elseif channel_short_name == "blog"}blog/post/{if:elseif channel_short_name == "events"}event/{if:else}article/{/if}{url_title}">{entry_date format="%F %j, %Y"}</a></time>
 
 						</footer>
 

--- a/templates/default_site/issue.group/index_skeleton.html
+++ b/templates/default_site/issue.group/index_skeleton.html
@@ -38,7 +38,7 @@
 		
 		<p>{title}</p>
 		
-		<time class="article-pubdate" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+		<time class="article-pubdate" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 	
 	</header>
 	

--- a/templates/default_site/mailchimp.group/digest-embed.html
+++ b/templates/default_site/mailchimp.group/digest-embed.html
@@ -14,7 +14,7 @@
 
                         <td valign="top" class="mcnTextContent" style="padding: 12px 30px;"><h3 style="text-align: center; font-family:'Franklin ITC Pro', 'ITC Franklin Gothic Std', 'Helvetica Neue', Helvetica, sans-serif; font-size:26px; font-style:normal; font-weight:600 !important; line-height:30px;">Recent Columns</h3> <ul>{/if}
         <li><a href="{site_url}/column/{url_title}">{title}</a><br>
-          By {embed="embeds/article-authors-for-rss-2" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"} on {entry_date format="%F %d, %Y"}</li>
+          By {embed="embeds/article-authors-for-rss-2" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"} on {entry_date format="%F %j, %Y"}</li>
         {if count == total_results}</ul></td>
                     </tr>
                 </tbody></table>
@@ -42,7 +42,7 @@
 
                         <td valign="top" class="mcnTextContent" style="padding: 12px 30px;"><h3 style="text-align: center; font-family:'Franklin ITC Pro', 'ITC Franklin Gothic Std', 'Helvetica Neue', Helvetica, sans-serif; font-size:26px; font-style:normal; font-weight:600 !important; line-height:30px;">Recent Blog Posts</h3> <ul>{/if}
         <li><a href="{site_url}/blog/post/{url_title}">{title}</a><br>
-          By {embed="embeds/article-authors-for-rss-2" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"} on {entry_date format="%F %d, %Y"}</li>
+          By {embed="embeds/article-authors-for-rss-2" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"} on {entry_date format="%F %j, %Y"}</li>
         {if count == total_results}</ul></td>
                     </tr>
                 </tbody></table>

--- a/templates/default_site/mailchimp_v2.group/feed-digest.feed
+++ b/templates/default_site/mailchimp_v2.group/feed-digest.feed
@@ -102,7 +102,7 @@
 
                         <td valign="top" class="mcnTextContent" style="padding: 12px 30px;"><h3 style="text-align: center; font-family:'Franklin ITC Pro', 'ITC Franklin Gothic Std', 'Helvetica Neue', Helvetica, sans-serif; font-size:26px; font-style:normal; font-weight:600 !important; line-height:30px;">Recent Columns</h3> <ul>{/if}
         <li><a href="{site_url}/column/{url_title}">{title}</a><br>
-          By {embed="embeds/article-authors-for-rss-2" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"} on {entry_date format="%F %d, %Y"}</li>
+          By {embed="embeds/article-authors-for-rss-2" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"} on {entry_date format="%F %j, %Y"}</li>
         {if count == total_results}</ul></td>
                     </tr>
                 </tbody></table>
@@ -130,7 +130,7 @@
 
                         <td valign="top" class="mcnTextContent" style="padding: 12px 30px;"><h3 style="text-align: center; font-family:'Franklin ITC Pro', 'ITC Franklin Gothic Std', 'Helvetica Neue', Helvetica, sans-serif; font-size:26px; font-style:normal; font-weight:600 !important; line-height:30px;">Recent Blog Posts</h3> <ul>{/if}
         <li><a href="{site_url}/blog/post/{url_title}">{title}</a><br>
-          By {embed="embeds/article-authors-for-rss-2" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"} on {entry_date format="%F %d, %Y"}</li>
+          By {embed="embeds/article-authors-for-rss-2" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"} on {entry_date format="%F %j, %Y"}</li>
         {if count == total_results}</ul></td>
                     </tr>
                 </tbody></table>

--- a/templates/default_site/main.group/index_TEST.html
+++ b/templates/default_site/main.group/index_TEST.html
@@ -91,7 +91,7 @@
 						<p>{column_intro}</p>
 
 						<footer class="byline">
-							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 						</footer>
 
 					</article>
@@ -133,7 +133,7 @@
 
 						<footer>
 							{embed="embeds/article-authors" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"}
-							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %d, %Y"}</a></time>
+							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %j, %Y"}</a></time>
 						</footer>
 
 					</article>

--- a/templates/default_site/main.group/index_v16.html
+++ b/templates/default_site/main.group/index_v16.html
@@ -102,7 +102,7 @@
 					<p>{column_intro}</p>
 
 					<footer class="byline">
-						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 					</footer>
 
 				</article>
@@ -123,7 +123,7 @@
 
 					<footer>
 						{exp:parse_url parts="host"}{blog_target_url}{/exp:parse_url} ·
-						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %d, %Y"}</a></time>
+						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %j, %Y"}</a></time>
 					</footer>
 
 				</article>
@@ -138,7 +138,7 @@
 
 					<footer>
 						<a class="author" href="/author/{embed:entry_username}">{author}</a>
-						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %d, %Y"}</a></time>
+						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %j, %Y"}</a></time>
 					</footer>
 
 				</article>

--- a/templates/default_site/main.group/index_v17b.html
+++ b/templates/default_site/main.group/index_v17b.html
@@ -87,7 +87,7 @@
 					<p>{column_intro}</p>
 
 					<footer class="byline">
-						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 					</footer>
 
 				</article>
@@ -108,7 +108,7 @@
 
 					<footer>
 						{exp:parse_url parts="host"}{blog_target_url}{/exp:parse_url} ·
-						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %d, %Y"}</a></time>
+						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %j, %Y"}</a></time>
 					</footer>
 
 				</article>
@@ -123,7 +123,7 @@
 
 					<footer>
 						<a class="author" href="/author/{embed:entry_username}">{author}</a>
-						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %d, %Y"}</a></time>
+						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %j, %Y"}</a></time>
 					</footer>
 
 				</article>

--- a/templates/default_site/main.group/index_v17c.html
+++ b/templates/default_site/main.group/index_v17c.html
@@ -31,7 +31,7 @@
 					<h1><a href="/column/{url_title}">{title}</a></h1>
 
 					<p class="meta">
-						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time> ·
+						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time> ·
 
 						Published in {modern-categories}
 
@@ -60,7 +60,7 @@
 
 					<footer>
 						{exp:parse_url parts="host"}{blog_target_url}{/exp:parse_url} ·
-						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %d, %Y"}</a></time>
+						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %j, %Y"}</a></time>
 					</footer>
 
 				</article>
@@ -75,7 +75,7 @@
 
 					<footer>
 						<a class="author" href="/author/{embed:entry_username}">{author}</a>
-						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %d, %Y"}</a></time>
+						<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %j, %Y"}</a></time>
 					</footer>
 
 				</article>

--- a/templates/default_site/preview.group/index.html
+++ b/templates/default_site/preview.group/index.html
@@ -88,7 +88,7 @@
 
 					<span itemprop="author" itemscope itemtype="http://schema.org/Person">by {article_authors backspace="2"}<a itemprop="url" class="author" rel="author" href="/author/{article_authors:url_title}"><span itemprop="name">{article_authors:title}</span></a>, {/article_authors}</span>
 
-					<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}" itemprop="datePublished">{entry_date format="%F %d, %Y"}</time>
+					<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}" itemprop="datePublished">{entry_date format="%F %j, %Y"}</time>
 
 					<span class="entry-meta optional-break">
 
@@ -399,7 +399,7 @@
 
 					<span itemprop="author" itemscope itemtype="http://schema.org/Person">by {legacy_article_authors backspace="2"}<a itemprop="url" class="author" rel="author" href="/author/{legacy_article_authors:url_title}"><span itemprop="name">{legacy_article_authors:title}</span></a>, {/legacy_article_authors}</span>
 
-					{exp:playa:parents status="open|In Progress"}<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}" itemprop="datePublished">{entry_date format="%F %d, %Y"}</time>{/exp:playa:parents}
+					{exp:playa:parents status="open|In Progress"}<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}" itemprop="datePublished">{entry_date format="%F %j, %Y"}</time>{/exp:playa:parents}
 
 					<span class="entry-meta optional-break">
 

--- a/templates/default_site/reports.group/all-blog-posts.html
+++ b/templates/default_site/reports.group/all-blog-posts.html
@@ -1,2 +1,2 @@
-{exp:channel:entries channel="blog" show_future_entries="yes" limit="999"}"{title}",{entry_date format="%F %d, %Y"},http://alistapart.com/blog/post/{url_title}
+{exp:channel:entries channel="blog" show_future_entries="yes" limit="999"}"{title}",{entry_date format="%F %j, %Y"},http://alistapart.com/blog/post/{url_title}
 {/exp:channel:entries}

--- a/templates/default_site/utilities.group/articles-and-illos.html
+++ b/templates/default_site/utilities.group/articles-and-illos.html
@@ -10,7 +10,7 @@
 						<h3 class="entry-title"><a href="/article/{url_title}">{title}</a></h3>
 						<p class="meta">
 							by {embed="embeds/article-authors" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"} · 
-							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+							<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 						</p>
 						<p>Has illo: 
 							{if article_illustration}<b style="color: green;">Yes</b>

--- a/templates/snippets/default_site/blog-posts-from-ala.snip
+++ b/templates/snippets/default_site/blog-posts-from-ala.snip
@@ -12,7 +12,7 @@
 							
 							<footer>
 								<span itemprop="author" itemscope itemtype="http://schema.org/Person">by {blog_authors backspace="2"}<a itemprop="url" class="author" rel="author" href="/author/{blog_authors:url_title}"><span itemprop="name">{blog_authors:title}</span></a>, {/blog_authors}</span>
-								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %d, %Y"}</a></time>
+								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %j, %Y"}</a></time>
 							</footer>
 						
 						</article>

--- a/templates/snippets/default_site/even-more-from-ala-backup.snip
+++ b/templates/snippets/default_site/even-more-from-ala-backup.snip
@@ -16,7 +16,7 @@
 							{if column_mini_deck}<p>{column_mini_deck}</p>{if:elseif column_intro}<p>{exp:trunchtml chars="175" inline="..."}{column_intro}{/exp:trunchtml}</p>{/if}
 					
 							<footer class="byline">
-								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 							</footer>
 						
 						</article>
@@ -38,7 +38,7 @@
 							
 							<footer>
 								{embed="embeds/article-authors" entry_author="{author}" entry_username="{username}" entry_id="{entry_id}"}
-								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %d, %Y"}</a></time>
+								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="/blog/post/{url_title}">{entry_date format="%F %j, %Y"}</a></time>
 							</footer>
 						
 						</article>

--- a/templates/snippets/default_site/link-post-content.snip
+++ b/templates/snippets/default_site/link-post-content.snip
@@ -8,7 +8,7 @@
 				<p class="url-display"><a href="{blog_target_url}">{blog_target_url} ›</a></p>
 
 				<p class="meta">
-					<time class="article-pubdate" datetime="{DATE_W3C}">{entry_date format="%F %d, %Y"}</time>
+					<time class="article-pubdate" datetime="{DATE_W3C}">{entry_date format="%F %j, %Y"}</time>
 				</p>
 
 				<p class="vcard screen-reader">

--- a/templates/snippets/default_site/more-from-ala-backup.snip
+++ b/templates/snippets/default_site/more-from-ala-backup.snip
@@ -15,7 +15,7 @@
 								{if "{categories}{category_url_title}{/categories}"!=""}
 								{embed="embeds/primary-category-logic-homepage" id="{entry_id}"}
 								Â·{/if}
-								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="{if channel_short_name == "columns"}column/{if:elseif channel_short_name == "blog"}blog/post/{if:elseif channel_short_name == "events"}event/{if:else}article/{/if}{url_title}">{entry_date format="%F %d, %Y"}</a></time>
+								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="{if channel_short_name == "columns"}column/{if:elseif channel_short_name == "blog"}blog/post/{if:elseif channel_short_name == "events"}event/{if:else}article/{/if}{url_title}">{entry_date format="%F %j, %Y"}</a></time>
 							</footer>
 
 						</article>

--- a/templates/snippets/default_site/more-from-ala-for-blog.snip
+++ b/templates/snippets/default_site/more-from-ala-for-blog.snip
@@ -15,7 +15,7 @@
 						</figure>
 						{/issue_illustration}
 
-						<h3 class="alternate">Issue № {issue_number} · <time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time></h3>
+						<h3 class="alternate">Issue № {issue_number} · <time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time></h3>
 
 						<ul class="entry-list">
 
@@ -54,7 +54,7 @@
 							{if column_mini_deck}<p>{exp:xhtml:light}{column_mini_deck}{/exp:xhtml:light}</p>{if:elseif column_intro}<p>{exp:xhtml:light}{exp:trunchtml chars="175" inline="..."}{column_intro}{/exp:trunchtml}{/exp:xhtml:light}</p>{/if}
 
 							<footer class="byline">
-								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 							</footer>
 
 						</article>

--- a/templates/snippets/default_site/more-from-ala-for-blog_safe_save_184305.snip
+++ b/templates/snippets/default_site/more-from-ala-for-blog_safe_save_184305.snip
@@ -34,7 +34,7 @@
 						</figure>
 						{/issue_illustration}
 
-						<h3 class="alternate">Issue № {issue_number} · <time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time></h3>
+						<h3 class="alternate">Issue № {issue_number} · <time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time></h3>
 
 						<ul class="entry-list">
 
@@ -73,7 +73,7 @@
 							{if column_mini_deck}<p>{column_mini_deck}</p>{if:elseif column_intro}<p>{exp:trunchtml chars="175" inline="..."}{column_intro}{/exp:trunchtml}</p>{/if}
 
 							<footer class="byline">
-								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %d, %Y"}</time>
+								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}">{entry_date format="%F %j, %Y"}</time>
 							</footer>
 
 						</article>

--- a/templates/snippets/default_site/more-from-ala.snip
+++ b/templates/snippets/default_site/more-from-ala.snip
@@ -28,7 +28,7 @@
 								{if "{categories}{category_url_title}{/categories}"!=""}
 								{embed="embeds/primary-category-logic-homepage" id="{entry_id}"}
 								·{/if}
-								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="{if channel_short_name == "columns"}column/{if:elseif channel_short_name == "blog"}blog/post/{if:elseif channel_short_name == "events"}event/{if:else}article/{/if}{url_title}">{entry_date format="%F %d, %Y"}</a></time>
+								<time class="pubdate updated" datetime="{entry_date format="%Y-%m-%dT%H:%i:%s%Q"}"><a href="{if channel_short_name == "columns"}column/{if:elseif channel_short_name == "blog"}blog/post/{if:elseif channel_short_name == "events"}event/{if:else}article/{/if}{url_title}">{entry_date format="%F %j, %Y"}</a></time>
 							</footer>
 
 						</article>


### PR DESCRIPTION
Closes #357.

Updates all instances of `{entry_date format="%F %d, %Y"}` to use `{entry_date format="%F %j, %Y"}`, which will remove the leading `0` from the day.

Ex: February 02, 2016 will become February 2, 2016.